### PR TITLE
Fix crash when `default-directory` is changed

### DIFF
--- a/flymake-python-pyflakes.el
+++ b/flymake-python-pyflakes.el
@@ -19,8 +19,7 @@
 (defun flymake-python-pyflakes-init ()
   (list flymake-python-pyflakes-executable
         (list
-         (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace)
-         (file-name-directory buffer-file-name))))
+         (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace))))
 
 ;;;###autoload
 (defun flymake-python-pyflakes-load ()


### PR DESCRIPTION
If `default-directory` is changed, flymake just gives an unhelpful error:

> switched OFF Flymake mode for buffer views.py due to fatal status CFGERR, warning Configuration error has occurred while running (~/.emacs.d/user-python/run-pyflakes views_flymake.py)

Enabling flymake logging (`M-x set-variable <RET> flymake-log-level <RET> 3 <RET>`) shows

> started process 13191, command=(~/.emacs.d/user-python/run-pyflakes views_flymake.py), dir=/home/wilfred/work/web/
> 
> parsed 'views_flymake.py: No such file or directory', no line-err-info

views_flymake.py was not in /home/wilfred/web, it was in a child directory. We should specify an absolute path.
