### PR TITLE
Show PEP8 errors as warnings

### DIFF
--- a/flymake-python-pyflakes.el
+++ b/flymake-python-pyflakes.el
@@ -42,7 +42,7 @@
                      flymake-python-pyflakes-err-line-patterns
                      'inplace
                      "py"
-                     "^W"))
+                     "^E[0-7][0-9][0-9]"))
 
 
 (provide 'flymake-python-pyflakes)


### PR DESCRIPTION
Since PEP8 violations are not compilation errors show them as warnings instead.
