### PR TITLE
Redefine some warnings as infos to distinguish style problems from possible errors

### DIFF
--- a/flymake-python-pyflakes.el
+++ b/flymake-python-pyflakes.el
@@ -63,6 +63,9 @@
       "\\(^redefinition\\|.*unused.*\\|used$\\)"
     "^\\([WFCN]\\|E[0-7]\\)"))
 
+(defconst flymake-python-pyflakes-info-regex
+  "^\\(F401\\|E303\\|E[2-3]\\|E501\\)")
+
 ;;;###autoload
 (defun flymake-python-pyflakes-load ()
   "Configure flymake mode to check the current buffer's python syntax using pyflakes."
@@ -72,7 +75,8 @@
                      'inplace
                      "py"
                      (flymake-python-pyflakes-warn-regex
-                      flymake-python-pyflakes-executable)))
+                      flymake-python-pyflakes-executable)
+                     flymake-python-pyflakes-info-regex))
 
 (provide 'flymake-python-pyflakes)
 ;;; flymake-python-pyflakes.el ends here


### PR DESCRIPTION
This list might not be generally viable and possibly not tuned.
If you dont agree with this maybe an defcustom could be used instead?

This is related to https://github.com/purcell/flymake-easy/pull/1
